### PR TITLE
Use praw.ini file to pass in client secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ data/
 
 *.env
 */env/*
+
+praw.ini

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ See trending stock tickers on Reddit and check Stock perfomance <br><br>
 
 #### Running Scripts
 - Go to `src/` directory.
-- Create a `.env` file and add the following
+- Create a `praw.ini` file with the following
 ```
-CLIENT_ID=<your client id>
-CLIENT_SECRET=<your client secret>
-USER_AGENT=<your user agent>
+[ClientSecrets]
+client_id=<your client id>
+client_secret=<your client secret>
+user_agent=<your user agent>
 ```
-- install required modules using `pip install -r requirements.txt`
+Note that the title of this section, `ClientSecrets`, is important because `ticker_counts.py` will specifically look for that title in the `praw.ini` file.
+- Install required modules using `pip install -r requirements.txt`
 - Run `ticker_count.py` first
 - Now run `yfinance_analysis.py`
 - You will be able to find your results in `data/` directory.
@@ -38,13 +40,13 @@ I would love to see more work done on this, I think this could be something very
 - [x] Turn it into python executable rather than notebook
 - [ ] Turn this into a local module that can be used in notebooks/python scripts
 - [ ] Scrape catalysts from DDs
-- [ ] Add visualisations 
+- [ ] Add visualisations
 - [ ] Add time series to figure out at what time did stock trend and what time did posts/comments on reddit spike
 - [ ] Scrape comments as well
 - [ ] NLP implementation for SA
 - [ ] Create a scoring model that takes into account upvotes/comments/awards and mentions
 
-Suggestions are appreciated. 
+Suggestions are appreciated.
 
 ### Donation
 If you like what I am doing, consider buying me a coffee this helps me give more time to this project and improve. <br><br>
@@ -53,6 +55,3 @@ If you like what I am doing, consider buying me a coffee this helps me give more
 ----
 
 If you decide to use this anywhere please give a credit to [@abbasmdj](https://twitter.com/abbasmdj) on twitter, also If you like my work, check out other projects on my [Github](https://github.com/iam-abbas) and my [personal blog](https://abbasmj.com).
-
-
-

--- a/src/ticker_counts.py
+++ b/src/ticker_counts.py
@@ -12,14 +12,7 @@ from operator import add
 from typing import Set
 from datetime import datetime
 from tqdm import tqdm
-from dotenv import load_dotenv
 
-
-# Load credtials from env
-load_dotenv()
-CLIENT_ID = os.environ.get('CLIENT_ID')
-CLIENT_SECRET = os.environ.get('CLIENT_SECRET')
-USER_AGENT = os.environ.get('USER_AGENT')
 
 # JB 02/07/2021 - Configparser introduced to scrape out some hardcode and allow removal of sensitive passwords
 
@@ -40,9 +33,7 @@ with open('./config/tickers.json') as tickerFile:
 
 # Scrape subreddits `r/robinhoodpennystocks` and `r/pennystocks`
 # Current it does fetch a lot of additional data like upvotes, comments, awards etc but not using anything apart from title for now
-reddit = praw.Reddit(client_id=CLIENT_ID,
-                     client_secret=CLIENT_SECRET,
-                     user_agent=USER_AGENT)
+reddit = praw.Reddit('ClientSecrets')
 subreddits = "+".join(json.loads(config['FilteringOptions']['Subreddits']))
 new_bets = reddit.subreddit(subreddits).new(limit=WEBSCRAPER_LIMIT)
 


### PR DESCRIPTION
I've made the following changes:

- Creation of the `Reddit` object in `ticker_counts.py` now automatically uses a `praw.ini` file located in the `src` directory. It currently looks for a section in the `praw.ini` file titled `ClientSecrets`, but can be changed depending on the user.
- `dotenv` has been removed from the import list.
- The README has been updated accordingly to describe this new process of handling client secrets.
- `praw.ini` has been added to `.gitignore`, but I didn't remove the `.env` entry (just in case). 

