### PR TITLE
Using .get() to retreive keys, to avoid KeyError if key is not present

### DIFF
--- a/back/yfinance_analysis.py
+++ b/back/yfinance_analysis.py
@@ -32,8 +32,8 @@ def getTickerInfo(ticker):
     
   # Standard Data
   info = yf.Ticker(ticker).info
-  tickerName = info["longName"]
-  tickerIndustry = info["industry"]
+  tickerName = info.get("longName")
+  tickerIndustry = info.get("industry")
 
   # previous Day close
   tickerClose = yf.Ticker(ticker).history(period="1d")["Close"].to_list()[-1]


### PR DESCRIPTION
I ran into the following error
`Traceback (most recent call last):
  File "yfinance_analysis.py", line 55, in <module>
    df_best[dataColumns] = df_best.Ticker.apply(getTickerInfo)
  File "/usr/local/lib/python3.7/site-packages/pandas/core/series.py", line 4108, in apply
    mapped = lib.map_infer(values, f, convert=convert_dtype)
  File "pandas/_libs/lib.pyx", line 2467, in pandas._libs.lib.map_infer
  File "yfinance_analysis.py", line 36, in getTickerInfo
    tickerIndustry = info["industry"]
KeyError: 'industry'`

My solution was to use .get() to retrieve the keys from info, which will handle if a key is not present.