### PR TITLE
Add an argument for the backend data file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .vscode
+.idea
 data/
 
 __pycache__
+venv
 
 *.env
 */env/*

--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ There's also a JavaScript web app that shows some data visualizations if you don
 Once you finished running the scripts, you'll have to set up the local server
 ```bash
 cd back
-python wsgi.py
+python wsgi.py [path to data file]
 ```
+
+The argument `[path to data file]` is optional and defaults to `./data/df_best_25.csv`. If you fetched a different
+number of tickers in the `yfinance_analysis.py` script, you'll want to use this argument to point to the data file that
+was created (e.g., `python yfinance_analysis.py 50` –> `./data/df_best_50.csv`). 
 
 Then, launch the client
 ```bash

--- a/back/server.py
+++ b/back/server.py
@@ -1,3 +1,4 @@
+import sys
 from flask import Flask, jsonify
 from flask_cors import CORS
 
@@ -5,11 +6,14 @@ import csv
 
 app = Flask(__name__)
 cors = CORS(app)
+data_file = sys.argv[1] if len(sys.argv) > 1 else './data/df_best_25.csv'
+
+print('Using data file {}'.format(data_file))
 
 
 @app.route('/get-basic-data', methods=['GET'])
 def get_basic_data() -> str:
-    with open('./data/df_best_25.csv', 'r') as f:
+    with open(data_file, 'r') as f:
         data = list(csv.reader(f))
 
     return jsonify(data)


### PR DESCRIPTION
This allows the backend to serve the correct finance data when the `yfinance_analysis` script was run with a different number of tickers.

e.g. `python yfinance_analysis.py 50` generates `./data/df_best_50.csv`, but the backend was previously hardcoded to look for `./data/df_best_25.csv`.