### PR TITLE
Fixing lack of beautifulsoup

### DIFF
--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -20,3 +20,4 @@ websocket-client==0.57.0
 yfinance==0.1.55
 flask==1.1.2
 flask_cors==3.0.10
+beautifulsoup4==4.9.3


### PR DESCRIPTION
The current `requirements` file doesn't contain beautifulsoup, which causes the error `ImportError: BeautifulSoup4 (bs4) not found, please install it` when execute `yfinance_analysis.py`