### PR TITLE
Prevent failure when long name or industry not found

### DIFF
--- a/back/yfinance_analysis.py
+++ b/back/yfinance_analysis.py
@@ -43,8 +43,17 @@ class FinanceAnalysis:
     def get_ticker_info(self, ticker):
         # Standard Data
         ticker = getattr(self.tickers.tickers, ticker)
-        ticker_name = ticker.info.get('longName')
-        ticker_industry = ticker.info.get('industry')
+
+        try:
+            ticker_name = ticker.info.get('longName')
+        except:
+            ticker_name = 'missing_longName'
+
+        try:
+            ticker_industry = ticker.info.get('industry')
+        except:
+            ticker_industry = 'missing_industry'
+
 
         df_hist_1mo = self.data[ticker.ticker]
         df_hist_5d = df_hist_1mo.iloc[-5:]


### PR DESCRIPTION
Fixes failure Value Error: Tables not found. Issue #61
The problem occurred when ticker.info.get('longName') and/or ticker.info.get('industry') do not find any values.
This includes a try-except block to catch the error and give a placeholder string that indicates the stock's long name and industry are missing.