### PR TITLE
Adds missing dependancy - html5lib

### DIFF
--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -1,6 +1,7 @@
 certifi==2020.12.5
 chardet==4.0.0
 configparser==5.0.1
+html5lib==1.1
 idna==2.10
 lxml==4.6.2
 multitasking==0.0.9


### PR DESCRIPTION
The current `requirements` file does not contain `html5lib `which results in an error similar to the one mentioned in #62 when running `yfinance_analysis.py`. Although I encountered the BeautfulSoup4 error as well, I did not add it to the requirements file as there is already a PR open for it. 

This error is also mentioned in #61.